### PR TITLE
Make magma work with python 3.8

### DIFF
--- a/rplugin/python3/magma/outputchunks.py
+++ b/rplugin/python3/magma/outputchunks.py
@@ -209,7 +209,7 @@ class Output:
 def to_outputchunk(
     alloc_file: Callable[
         [str, str],
-        AbstractContextManager[Tuple[str, IO[bytes]]],
+        "AbstractContextManager[Tuple[str, IO[bytes]]]",
     ],
     data: Dict[str, Any],
     metadata: Dict[str, Any],


### PR DESCRIPTION
I am a big fan of making magma work with arbitrary kernels via a kernel spec json files. However I was not able to make magma work with python 3.8 which is my main python version (worked fine with python 3.9).
The error I got on `MagmaInit` was:
```
...
TypeError: 'ABCMeta' object is not subscriptable
....
```

it turns out some of the more complicated typing is not supported by python 3.8
the simple fix is turning this type annotation into a string and `MagmaInit` works like a charm


